### PR TITLE
ws2811.c: fix build with gcc 4.8

### DIFF
--- a/ws2811.c
+++ b/ws2811.c
@@ -1286,13 +1286,14 @@ const char * ws2811_get_return_t_str(const ws2811_return_t state)
 
 void ws2811_set_custom_gamma_factor(ws2811_t *ws2811, double gamma_factor)
 {
-    for (int chan = 0; chan < RPI_PWM_CHANNELS; chan++)
+    int chan, counter;
+    for (chan = 0; chan < RPI_PWM_CHANNELS; chan++)
     {
         ws2811_channel_t *channel = &ws2811->channel[chan];
 
         if (channel->gamma)
         {
-          for(int counter = 0; counter < 256; counter++)
+          for(counter = 0; counter < 256; counter++)
           {
 
              channel->gamma[counter] = (gamma_factor > 0)? (int)(pow((float)counter / (float)255.00, gamma_factor) * 255.00 + 0.5) : counter;


### PR DESCRIPTION
Fix the following build failure with gcc 4.8 (which has been added by commit 391f6e856d28510bd9ae4efd3a166da7f73613ab):

```
lib/ws2811.c: In function 'ws2811_set_custom_gamma_factor':
lib/ws2811.c:1289:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int chan = 0; chan < RPI_PWM_CHANNELS; chan++)
     ^
lib/ws2811.c:1289:5: note: use option -std=c99 or -std=gnu99 to compile your code
lib/ws2811.c:1295:11: error: 'for' loop initial declarations are only allowed in C99 mode
           for(int counter = 0; counter < 256; counter++)
           ^
```

Fixes:
 - http://autobuild.buildroot.org/results/3d037922484bfc45d0f985f87b38f20c5a4ab064

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>